### PR TITLE
Fix binder

### DIFF
--- a/.binder/postBuild
+++ b/.binder/postBuild
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Copyright (c) 2021 University System of Georgia and GTCOARLab Contributors
 # Distributed under the terms of the BSD-3-Clause License
-set -eux
+set -ex
 export MAMBA_NO_BANNER=1
 
 CONDARC=$(pwd)/.github/.condarc

--- a/README.md
+++ b/README.md
@@ -6,12 +6,16 @@ _an environment for interactive exploration of reinforcement learning_
 | :----------------------------------: | :------------------------------------------: |
 | [![view latest build][ci-badge]](ci) | [![launch demo on binder][demo-badge]][demo] |
 
-[ci]: https://github.com/gt-coar/gt-coar-lab/actions
-[ci-badge]: https://github.com/gt-coar/gt-coar-lab/workflows/Build%20Installer/badge.svg
-[demo-badge]: https://mybinder.org/badge_logo.svg
-[demo]: https://mybinder.org/v2/gh/gt-coar/gt-coar-lab/master?urlpath=lab
+[![a screenshot of GTCOARLab running gym-atari on mybinder.org][screenshot]][screenshot-issue]
 
----
+[ci]: https://github.com/gt-coar/gt-coar-lab/actions
+[ci-badge]: https://github.com/gt-coar/gt-coar-lab/workflows/CI/badge.svg
+[demo-badge]: https://mybinder.org/badge_logo.svg
+[demo]:
+  https://mybinder.org/v2/gh/gt-coar/gt-coar-lab/master?urlpath=lab/notebooks/Headless%20Gym.ipynb
+[screenshot]:
+  https://user-images.githubusercontent.com/7581399/111483945-ab1b1180-870b-11eb-8ce3-2bd81b205733.png
+[screenshot-issue]: https://github.com/gt-coar/gt-coar-lab/issues/16
 
 > Copyright (c) 2021 University System of Georgia and GTCOARLab Contributors
 >


### PR DESCRIPTION
Some of the deeper activation scripts are broken, this just removes `-u` so binder can build.

https://mybinder.org/v2/gh/nrbgt/gt-coar-lab/fix-binder?urlpath=lab